### PR TITLE
Fix docker example for newer tfm and clean all temps

### DIFF
--- a/examples/1_docker_without_gcp/1_clear.sh
+++ b/examples/1_docker_without_gcp/1_clear.sh
@@ -3,11 +3,14 @@
 # Remove any existing cog SSH keys
 rm -rf keys terraform/keys
 
-# Remove any existing terraform directory
-rm -rf terraform/.terraform
+# Remove existing terraform directory and lock
+rm -rf terraform/.terraform terraform/.terraform.lock.hcl
 
 # Stop and remove containers, networks, images, and volumes 
 docker-compose down
+
+# Remove vault data
+sudo rm -rf vault/data/
 
 # Remove any persistent vault data
 rm -rf vault/{data,file,logs} VAULT_PASSWORD vault_initialization.log

--- a/examples/1_docker_without_gcp/terraform/modules/user_accounts/main.tf
+++ b/examples/1_docker_without_gcp/terraform/modules/user_accounts/main.tf
@@ -25,7 +25,7 @@ resource "vault_ssh_secret_backend_role" "user_account" {
   backend                 = "ssh"
   key_type                = "ca"
   allow_user_certificates = true
-  allowed_users           = join(",", compact(concat(list(var.username), var.unix_roles)))
+  allowed_users           = join(",", compact(concat(tolist([var.username]), var.unix_roles)))
 
   default_extensions = {
     "permit-agent-forwarding" = ""
@@ -34,6 +34,6 @@ resource "vault_ssh_secret_backend_role" "user_account" {
     "permit-X11-forwarding"   = ""
   }
 
-  default_user = join(",", compact(concat(list(var.username), var.unix_roles)))
+  default_user = join(",", compact(concat(tolist([var.username]), var.unix_roles)))
   ttl          = var.ssh_sign_ttl
 }


### PR DESCRIPTION
@maroux 

In examples/1_docker_without_gcp:

- In newer terraform versions, the `list()` function has been removed.
-- Use `tolist([string])` which is available since terraform 0.12:
   https://www.terraform.io/language/functions/list

- Fix `1_clear.sh` to also remove the terraform lock and vault data.