### PR TITLE
Use `tolist([string])` which is available since terraform 0.12

### DIFF
--- a/terraform/1_gcp_infrastructure/variables.tf
+++ b/terraform/1_gcp_infrastructure/variables.tf
@@ -27,7 +27,7 @@ variable "gcp_storage_bucket_storage_class" {
 
 variable "gcp_iap_https_firewall_source_ranges" {
   description = "GCP Firewall IP ranges (https://cloud.google.com/iap/docs/load-balancer-howto#firewall)"
-  type        = list(string)
+  type        = tolist([string])
   default = [
     "130.211.0.0/22",
     "35.191.0.0/16",
@@ -36,7 +36,7 @@ variable "gcp_iap_https_firewall_source_ranges" {
 
 variable "gcp_iap_all_firewall_source_ranges" {
   description = "GCP IAP Firewall IP ranges"
-  type        = list(string)
+  type        = tolist([string])
   default = [
     "35.235.240.0/20",
   ]
@@ -131,7 +131,7 @@ variable "oauth2_client_secret" {
 
 variable "vault_iam_members" {
   description = "Vault IAM members"
-  type        = list(string)
+  type        = tolist([string])
 }
 
 variable "openssl_subject" {
@@ -141,7 +141,7 @@ variable "openssl_subject" {
 
 variable "iam_roles_owners" {
   description = "Members who get roles/owner"
-  type        = list(string)
+  type        = tolist([string])
 }
 
 variable "iap_email_address" {

--- a/terraform/3_users/modules/user_accounts/main.tf
+++ b/terraform/3_users/modules/user_accounts/main.tf
@@ -14,7 +14,7 @@ resource "vault_ssh_secret_backend_role" "user_account" {
   backend                 = "ssh"
   key_type                = "ca"
   allow_user_certificates = true
-  allowed_users           = join(",", compact(concat(list(var.username), var.unix_roles)))
+  allowed_users           = join(",", compact(concat(tolist([var.username]), var.unix_roles)))
 
   default_extensions = {
     "permit-agent-forwarding" = ""
@@ -23,6 +23,6 @@ resource "vault_ssh_secret_backend_role" "user_account" {
     "permit-X11-forwarding"   = ""
   }
 
-  default_user = join(",", compact(concat(list(var.username), var.unix_roles)))
+  default_user = join(",", compact(concat(tolist([var.username]), var.unix_roles)))
   ttl          = var.ssh_sign_ttl
 }

--- a/terraform/3_users/variables.tf
+++ b/terraform/3_users/variables.tf
@@ -17,15 +17,15 @@ variable "oidc_default_role" {
 }
 
 variable "reader_role_bound_audiences" {
-  type = list(string)
+  type = tolist([string])
 }
 
 variable "reader_role_allowed_redirect_uris" {
-  type = list(string)
+  type = tolist([string])
 }
 
 variable "role_members_default" {
-  type = list(string)
+  type = tolist([string])
 }
 
 variable "oidc_mount_accessor" {


### PR DESCRIPTION
- In newer terraform versions, the `list()` function has been removed.
-- Use `tolist([string])` which is available since terraform 0.12:
   https://www.terraform.io/language/functions/list
   
@maroux For `examples/1_docker_without_gcp` please see #9